### PR TITLE
Don't trigger console errors when EmptyResponse is returned

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -72,7 +72,7 @@ app.initializers.add('malago-achievements', app => {
   extend(Application.prototype, 'request', function (promise) {
     if (promise) {
       promise.then(function (data) {
-        if (data.new_achievements !== undefined && data.new_achievements !== null && data.new_achievements.length > 0)
+        if (data && data.new_achievements !== undefined && data.new_achievements !== null && data.new_achievements.length > 0)
           app.modal.show(NewAchievementModal, { achievements: data.new_achievements });
       });
     }


### PR DESCRIPTION
Some routes return EmptyResponse, which won't have data attached to it. This check makes sure we don't try to handle this case.